### PR TITLE
Update `provider_id` for CBeebies and CBBC

### DIFF
--- a/channels.json
+++ b/channels.json
@@ -641,7 +641,7 @@
       "src": "sky",
       "lang": "en",
       "xmltv_id": "CBeebies.uk",
-      "provider_id": "2078",
+      "provider_id": "2088",
       "icon_url": "https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-kingdom/bbc-cbeebies-uk.png",
       "name": "CBeebies"
     },

--- a/channels.json
+++ b/channels.json
@@ -633,7 +633,7 @@
       "src": "sky",
       "lang": "en",
       "xmltv_id": "CBBC.uk",
-      "provider_id": "1095",
+      "provider_id": "2078",
       "icon_url": "https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-kingdom/bbc-cbbc-uk.png",
       "name": "CBBC"
     },
@@ -641,7 +641,7 @@
       "src": "sky",
       "lang": "en",
       "xmltv_id": "CBeebies.uk",
-      "provider_id": "1093",
+      "provider_id": "2078",
       "icon_url": "https://raw.githubusercontent.com/tv-logo/tv-logos/main/countries/united-kingdom/bbc-cbeebies-uk.png",
       "name": "CBeebies"
     },


### PR DESCRIPTION
- The `provider_id` for some BBC channels have been updated since SD was turned off.