### PR TITLE
Refactor code to mitigate missing programme IDs

### DIFF
--- a/main.py
+++ b/main.py
@@ -376,19 +376,20 @@ for channel in channels_data:
                 continue
             epg_data = json.loads(req.text)
             for item in epg_data:
-                programme_id = item['id']
-                details_request = requests.get(f"https://www.radiotimes.com/api/broadcast/broadcast/details/{programme_id}")
-                if details_request.status_code != 200:
-                    break
-                details_json = json.loads(details_request.text)
+                if 'id' in item:
+                    programme_id = item['id']
+                    details_request = requests.get(f"https://www.radiotimes.com/api/broadcast/broadcast/details/{programme_id}")
+                    if details_request.status_code != 200:
+                        break
+                    details_json = json.loads(details_request.text)
+                    desc = details_json['description'] if 'description' in details_json else None
+                    if details_json.get('image').get('url') is not None:
+                        icon = details_json.get('image').get('url')
+                    else:
+                        icon = None
                 title = item['title']
-                desc = details_json['description'] if 'description' in details_json else None
                 start = datetime.strptime(item['start'], '%Y-%m-%dT%H:%M:%SZ')
                 end = datetime.strptime(item['end'], '%Y-%m-%dT%H:%M:%SZ')
-                if details_json.get('image').get('url') is not None:
-                    icon = details_json.get('image').get('url')
-                else:
-                    icon = None
                 ch_name = channel.get('xmltv_id')
 
                 # if end < (start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(1)):


### PR DESCRIPTION
Problem: RT doesn't always provide a programme ID, for example, if the channel is off air. Because the parser looks for the ID to generate the description URL, when it is missing it hits an error.

Solution: Refactor code so that the ID is only used if it exists. Programmes will then always have a title and start/end time, but description and images are extras