### PR TITLE
Enable pip caching for build_epg

### DIFF
--- a/.github/workflows/build_epg.yml
+++ b/.github/workflows/build_epg.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Enables pip cache for the setup-python action, reducing running time and cpu/network usage, when packages haven't been updated in the last 8 hours.