### PR TITLE
Add manual `workflow_dispatch` trigger to build_epg workflow

### DIFF
--- a/.github/workflows/build_epg.yml
+++ b/.github/workflows/build_epg.yml
@@ -3,6 +3,7 @@ name: Build EPG
 on:
   schedule:
     - cron: '0 */12 * * *'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
### Motivation
- Allow the Build EPG workflow to be run on demand in addition to its existing 12-hour schedule so EPG builds can be triggered manually when needed.

### Description
- Add `workflow_dispatch` to `.github/workflows/build_epg.yml` to enable manual triggering of the workflow without changing any of the job steps.

### Testing
- No automated tests were run because this is a CI workflow configuration change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2bed4da0832db8cb914b4791ad65)