### PR TITLE
Update channels.json with a few missing Radio Channels from Radio Times.

### DIFF
--- a/channels.json
+++ b/channels.json
@@ -2059,12 +2059,36 @@
       "name": "LBC"
     },
     {
+      "src": "rt",
+      "lang": "en",
+      "xmltv_id": "PlanetRock.uk",
+      "provider_id": "httg",
+      "icon_url": "https://raw.githubusercontent.com/dp247/mediaportal-uk-logos/master/Radio/Planet-Rock.png",
+      "name": "Planet Rock"
+    },
+    {
+      "src": "rt",
+      "lang": "en",
+      "xmltv_id": "PremierRadio.uk",
+      "provider_id": "htmp",
+      "icon_url": "https://raw.githubusercontent.com/dp247/mediaportal-uk-logos/master/Radio/Premier-Radio.png",
+      "name": "Premier Radio"
+    },
+    {
       "src": "sky",
       "lang": "en",
       "xmltv_id": "RadioX.uk",
       "provider_id": "2904",
       "icon_url": "https://raw.githubusercontent.com/dp247/mediaportal-uk-logos/master/Radio/Radio-X.png",
       "name": "Radio X"
+    },
+    {
+      "src": "rt",
+      "lang": "en",
+      "xmltv_id": "RNIBConnectRadio.uk",
+      "provider_id": "hwbr",
+      "icon_url": "https://raw.githubusercontent.com/dp247/mediaportal-uk-logos/master/Radio/RNIB-Connect-Radio.png",
+      "name": "RNIB Connect"
     },
     {
       "src": "sky",


### PR DESCRIPTION
Had some spare time, so here's my attempt at addressing Channel Request - [Issue #95 ](https://github.com/dp247/Freeview-EPG/issues/95) that I raised yesterday.  I've also added a couple of other missing radio stations that are in the Radio Times feed, and which also appear in my own freeview-based TVHeadend config.

N.B. This definitely needs checking, as I've not actually ran any tests against it.  The xmltv_id values need to be reviewed, as as I'm unclear on the naming standard and they may not be valid!