### PR TITLE
Add category tag support and fix schedule gaps in XMLTV writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,4 @@ cython_debug/
 !/sky.com.channels_orig.xml
 !/sky.com.channels_orig.xml
 /.idea/Freeview-EPG.iml
+.vscode/settings.json

--- a/src/providers/radiotimes.py
+++ b/src/providers/radiotimes.py
@@ -5,12 +5,42 @@ Fetches programme data from the RadioTimes API. For the required number of days,
 a schedule endpoint is queried. Additional details for each episode are retrieved 
 to obtain descriptions and images. Duplicate broadcasts (with the same start time) 
 are skipped to avoid repeated entries.
+
+RadioTimes represents periods where a local station simulcasts a national feed
+(or otherwise has no unique listing) as ``type: "offAir"`` entries, and these
+entries often omit ``start``/``end`` on the boundaries of the requested range.
+Previously these were dropped entirely, leaving large holes in the guide. They
+are now converted into filler programmes so the output has no gaps.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from .base import Context
+
+FILLER_TITLE = "No Schedule Information"
+
+
+def _parse_timestamp(raw: Optional[str]) -> Optional[datetime]:
+    """Parse an RT ISO-8601 timestamp, returning ``None`` if absent/invalid."""
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def _filler(xmltv_id: str, start_ts: float, end_ts: float) -> Dict[str, Any]:
+    """Build a placeholder programme covering a gap in the schedule."""
+    return {
+        "title": FILLER_TITLE,
+        "description": None,
+        "start": start_ts,
+        "stop": end_ts,
+        "icon": None,
+        "channel": xmltv_id,
+    }
 
 
 def fetch_programmes(channel: Dict[str, Any], ctx: Context) -> List[Dict[str, Any]]:
@@ -33,10 +63,11 @@ def fetch_programmes(channel: Dict[str, Any], ctx: Context) -> List[Dict[str, An
 
     details_cache = ctx.caches.setdefault("rt_details", {})
 
-    prev_start: float | None = None
+    prev_end: Optional[float] = None
     for date in date_list:
+        day_end = date + timedelta(days=1)
         from_str = date.strftime("%Y-%m-%dT%H:%M:%S.000Z")
-        to_str = (date + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        to_str = day_end.strftime("%Y-%m-%dT%H:%M:%S.000Z")
         url = (
             f"https://www.radiotimes.com/api/broadcast/broadcast/channels/{provider_id}/schedule"
             f"?from={from_str}&to={to_str}"
@@ -51,8 +82,24 @@ def fetch_programmes(channel: Dict[str, Any], ctx: Context) -> List[Dict[str, An
         if not epg_data:
             continue
         for item in epg_data:
-            if item.get("type") != "episode":
+            # Boundary entries can omit start/end; fall back to the day's bounds.
+            start_dt = _parse_timestamp(item.get("start"))
+            end_dt = _parse_timestamp(item.get("end"))
+            start_ts = start_dt.timestamp() if start_dt else date.timestamp()
+            end_ts = end_dt.timestamp() if end_dt else day_end.timestamp()
+            if end_ts <= start_ts:
                 continue
+
+            # Fill any hole left before this item (e.g. an errored day or missing slot).
+            if prev_end is not None and start_ts > prev_end:
+                programmes.append(_filler(xmltv_id, prev_end, start_ts))
+
+            if item.get("type") == "offAir":
+                # Off-air/simulcast slot with no unique listing: use a filler instead of a gap.
+                programmes.append(_filler(xmltv_id, start_ts, end_ts))
+                prev_end = end_ts
+                continue
+
             # Fetch details for description and image
             desc = None
             icon = None
@@ -75,22 +122,21 @@ def fetch_programmes(channel: Dict[str, Any], ctx: Context) -> List[Dict[str, An
                 except Exception:
                     pass
             title = item.get("title")
-            # Parse start and end times as timezone-aware datetimes
-            start_raw = item.get("start")
-            end_raw = item.get("end")
-            try:
-                start_dt = datetime.strptime(start_raw, "%Y-%m-%dT%H:%M:%SZ").replace(
-                    tzinfo=timezone.utc
-                )
-                end_dt = datetime.strptime(end_raw, "%Y-%m-%dT%H:%M:%SZ").replace(
-                    tzinfo=timezone.utc
-                )
-            except Exception:
-                continue
-            start_ts = start_dt.timestamp()
-            end_ts = end_dt.timestamp()
-            # Skip duplicate broadcasts with the same start time
-            if prev_start is not None and prev_start == start_ts:
+
+            category = None
+            if item.get("genre") and len(item.get("genre")) > 0:
+                category = ', '.join([g.get("name", "").capitalize() for g in item.get("genre")]).strip()
+            if category is not None and item.get("type") == "film":
+                category = "Film, " + category
+            elif item.get("type") == "film":
+                category = "Movie"
+
+            # Skip duplicate broadcasts with the same start time as the previous real entry
+            if (
+                programmes
+                and programmes[-1].get("title") != FILLER_TITLE
+                and programmes[-1].get("start") == start_ts
+            ):
                 continue
             programmes.append(
                 {
@@ -100,7 +146,8 @@ def fetch_programmes(channel: Dict[str, Any], ctx: Context) -> List[Dict[str, An
                     "stop": end_ts,
                     "icon": icon,
                     "channel": xmltv_id,
+                    "category": category,
                 }
             )
-            prev_start = start_ts
+            prev_end = end_ts
     return programmes

--- a/src/xmltv.py
+++ b/src/xmltv.py
@@ -164,6 +164,12 @@ def build_xmltv(channels: List[Dict], programmes: List[Dict], tz) -> bytes:
             ep_os.set("system", "onscreen")
             ep_os.text = f"S{season}E{episode}"
 
+        if pr.get("category") is not None:
+            for cat in pr.get("category").split(","):
+                cat_el = etree.SubElement(programme_el, "category")
+                cat_el.set("lang", "en")
+                cat_el.text = cat.strip()
+
     # Return the pretty-printed XML string as bytes
     return etree.tostring(root, pretty_print=True, encoding="utf-8")
 


### PR DESCRIPTION
This pull request improves how the RadioTimes provider handles gaps in schedule data and enhances programme metadata. The main changes ensure that "offAir" periods (where no unique schedule is provided) are now represented as filler programmes instead of being omitted, which prevents gaps in the generated guide. Additionally, programme categories are now extracted and included in the XMLTV output.

**Handling schedule gaps and off-air periods:**
- "offAir" entries from RadioTimes, which previously resulted in missing schedule gaps, are now converted into filler programmes titled "No Schedule Information" to ensure continuous guide data. [[1]](diffhunk://#diff-156cc3995f198e8f120d5c86bb39cfed3a51eca130c5faf2f00604e89a9bfb3bR8-R44) [[2]](diffhunk://#diff-156cc3995f198e8f120d5c86bb39cfed3a51eca130c5faf2f00604e89a9bfb3bL54-R102)

**Programme metadata improvements:**
- Programme categories are now parsed from the RadioTimes data and included in each programme entry. For films, the category is prefixed with "Film" or set as "Movie" if no genre is present.
- The XMLTV generator (`src/xmltv.py`) now outputs `<category>` elements for each programme, supporting multiple categories per entry.

**Code refactoring and bug fixes:**
- Improved timestamp parsing and handling of missing or invalid start/end times, defaulting to day boundaries when necessary. [[1]](diffhunk://#diff-156cc3995f198e8f120d5c86bb39cfed3a51eca130c5faf2f00604e89a9bfb3bR8-R44) [[2]](diffhunk://#diff-156cc3995f198e8f120d5c86bb39cfed3a51eca130c5faf2f00604e89a9bfb3bL36-R70) [[3]](diffhunk://#diff-156cc3995f198e8f120d5c86bb39cfed3a51eca130c5faf2f00604e89a9bfb3bL54-R102)
- Duplicate broadcast detection now skips only real (non-filler) entries, improving schedule accuracy.

These changes result in a more accurate and complete EPG, with no gaps and richer metadata for each programme.